### PR TITLE
Use RawGit to load HTMLOutliner.js from Github repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "master"]
+	path = master
+	url = git://github.com/hoyois/html5outliner.git

--- a/index.xhtml
+++ b/index.xhtml
@@ -6,7 +6,7 @@
 	<title>HTML5 Outliner</title>
 	<link rel="stylesheet" href="../styles.css"/>
 	<link rel="stylesheet" href="frontend.css"/>
-	<script src="https://raw.github.com/hoyois/html5outliner/master/HTMLOutliner.js"></script>
+	<script src="master/HTMLOutliner.js"></script>
 	<script src="HTMLParser.js"></script>
 	<script src="frontend.js"></script>
 </head>


### PR DESCRIPTION
raw.github.com provides script files with `text/plain` MIME type so they are not executable on browsers.
[RawGit](http://rawgit.com/) solves this problem.
